### PR TITLE
Update the timer in the formspec in real-time

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -69,7 +69,12 @@ minetest.register_chatcommand("tpn", {
 minetest.register_chatcommand("tpf", {
 	description = S("Show all teleport requests, made by you or to you, that are still active"),
 	privs = {interact = true, tp = true},
-	func = tp.list_requests
+	func = function(player)
+		local playername = minetest.get_player_by_name(player)
+
+		tp.tpf_update_time[playername] = true
+		tp.list_requests(playername)
+	end
 })
 
 minetest.register_chatcommand("tpr_mute", {

--- a/init.lua
+++ b/init.lua
@@ -31,10 +31,11 @@ local S = minetest.get_translator(minetest.get_current_modname())
 
 tp = {
 	S = S,
-	tpr_list = {},
-	tphr_list = {},
-	tpc_list = {},
-	tpn_list = {}
+	tpr_list = { },
+	tphr_list = { },
+	tpc_list = { },
+	tpn_list = { },
+	tpf_update_time = { }
 }
 
 -- Clear requests when the player leaves


### PR DESCRIPTION
Things added/changed:

- Update the timer in the formspec in real-time

## To do

Ready for review.

## How to test

1. Send a request to a player.
2. Run the `/tpf` command. You will notice that the timer is increasing in real-time.
3. Try quitting the formspec and cancelling the request. The formspec shouldn't show up unless specified.
