### PR TITLE
Fix teleportation bug allowing self-teleportation

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -487,6 +487,12 @@ end
 
 -- Teleport Request System
 function tp.tpr_send(sender, receiver)
+	-- Check if the sender is the receiver
+	if sender == receiver then
+		send_message(sender, S("You cannot send a teleport request to yourself."))
+		return
+	end
+
 	-- Check if the sender is muted
 	if muted_players[receiver] == sender and not minetest.check_player_privs(sender, {server = true}) then
 		send_message(sender, S("Cannot send request to @1 (you have been muted).", receiver))
@@ -588,6 +594,12 @@ function tp.tpr_send(sender, receiver)
 end
 
 function tp.tphr_send(sender, receiver)
+	-- Check if the sender is the receiver
+	if sender == receiver then
+		send_message(sender, S("You cannot send a teleport request to yourself."))
+		return
+	end
+	
 	-- Check if the sender is muted
 	if muted_players[receiver] == sender and not minetest.check_player_privs(sender, {server = true}) then
 		send_message(sender, S("Cannot send request to @1 (you have been muted).", receiver))

--- a/functions.lua
+++ b/functions.lua
@@ -594,7 +594,7 @@ function tp.tpr_send(sender, receiver)
 end
 
 function tp.tphr_send(sender, receiver)
-	-- Check if the sender is the receiver
+	-- Disallow entering inaccessible areas. (Teleportation includes a position offset of 1)
 	if sender == receiver then
 		send_message(sender, S("You cannot send a teleport request to yourself."))
 		return

--- a/functions.lua
+++ b/functions.lua
@@ -599,7 +599,7 @@ function tp.tphr_send(sender, receiver)
 		send_message(sender, S("You cannot send a teleport request to yourself."))
 		return
 	end
-	
+
 	-- Check if the sender is muted
 	if muted_players[receiver] == sender and not minetest.check_player_privs(sender, {server = true}) then
 		send_message(sender, S("Cannot send request to @1 (you have been muted).", receiver))

--- a/functions.lua
+++ b/functions.lua
@@ -487,7 +487,7 @@ end
 
 -- Teleport Request System
 function tp.tpr_send(sender, receiver)
-	-- Check if the sender is the receiver
+	-- Disallow entering inaccessible areas. (Teleportation includes a position offset of 1)
 	if sender == receiver then
 		send_message(sender, S("You cannot send a teleport request to yourself."))
 		return


### PR DESCRIPTION
Adds a condition that makes it impossible to teleport to yourself because you can enter a protected area with /tpr <your_name> because when you use this command, you are teleported with 1 offset block.

- A condition for banning self-teleportation

## To do

Draft PR / Ready for review.

- [x] Fixes

## How to test

Use /tpr <your_name> and you will see a message telling you that you cannot teleport to yourself.
